### PR TITLE
chore: remove unused transformers from .deepsource.toml

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -12,9 +12,3 @@ name = "javascript"
     "vitest",
     "nodejs"
   ]
-
-[[transformers]]
-name = "prettier"
-
-[[transformers]]
-name = "standardjs"


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Remove unused Prettier and StandardJS transformer entries from .deepsource.toml