### PR TITLE
chore: fix typo in release configuration by changing 'auto-change-log…

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -13,7 +13,7 @@
             "bun test"
         ],
         "after:bump": [
-            "bunx auto-change-log -p"
+            "bunx auto-changelog -p"
         ]
     },
     "npm": {


### PR DESCRIPTION
…' to 'auto-changelog'